### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For the most current version of the applications using this database, visit http
 #### Database field descriptions:
 
 
-#####hygdata_v3.csv:  This is the current version (3) of the HYG stellar database.  It is similar to the version 2 (hygxyz.csv) file, but has a few updates.  The older file is now deprecated.
+##### hygdata_v3.csv:  This is the current version (3) of the HYG stellar database.  It is similar to the version 2 (hygxyz.csv) file, but has a few updates.  The older file is now deprecated.
 
 1. All stars now have both an epoch and equinox of 2000.0.  In v2 of the catalog, all three primary source catalogs either had or were adjusted to equinox 2000, but all 3 had different epochs, leading to small position errors at high magnifications.
 2. The Flamsteed numbers now include many that were not in the _Yale Bright Star Catalog_, the
@@ -47,7 +47,7 @@ Fields in the database:
 24. var:  Star's standard variable star designation, when known.
 25. var\_min, var\_max:  Star's approximate magnitude range, for variables.  This value is based on the Hp magnitudes for the range in the original Hipparcos catalog, adjusted to the V magnitude scale to match the "mag" field.
 
-#####dso.csv:  This is a collection of deep-sky objects used in http://www.astronexus.com/endeavour/chart.  
+##### dso.csv:  This is a collection of deep-sky objects used in http://www.astronexus.com/endeavour/chart.  
 There are approximately 220K objects, mostly galaxies, but also all known NGC and IC objects.
 
 
@@ -87,7 +87,7 @@ Catalogs represented in the database:
 
 These are still available, but are no longer current or being actively updated, and should be considered deprecated for higher-precision applications.
 
-#####hygfull.csv:
+##### hygfull.csv:
 
 1. StarID: The database primary key from a larger "master database" of stars.
 2. HD: The star's ID in the Henry Draper catalog, if known.
@@ -102,7 +102,7 @@ These are still available, but are no longer current or being actively updated, 
 11. Spectrum: The star's spectral type, if known.
 12. ColorIndex: The star's color index (blue magnitude - visual magnitude), where known.
                                                        
-#####hygxyz.csv: the fields in hygfull, plus some additional fields useful for mapping tools:
+##### hygxyz.csv: the fields in hygfull, plus some additional fields useful for mapping tools:
 
 13. X,Y,Z: The Cartesian coordinates of the star, in a system based on the equatorial coordinates as seen from Earth. +X is in the direction of the vernal equinox (at epoch 2000), +Z towards the north celestial pole, and +Y in the direction of R.A. 6 hours, declination 0 degrees.
 14. VX,VY,VZ: The Cartesian velocity components of the star, in the same coordinate system described immediately above. They are determined from the proper motion and the radial velocity (when known). The velocity unit is parsecs per year; these are small values (around 10-5 to 10-6), but they enormously simplify calculations using parsecs as base units for celestial mapping.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
