### PR TITLE
various minor fixes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-### **Welcome to the HYG star database archive.  The most current version of the database will always be found here. 
+### Welcome to the HYG star database archive.  The most current version of the database will always be found here. 
  
 For additional background details, and older versions of the database, visit  http://www.astronexus.com/hyg.
 
-For the most current version of the applications using this database, visit http://www.astronexus.com/endeavour. **
+For the most current version of the applications using this database, visit http://www.astronexus.com/endeavour. 
 
 #### Database field descriptions:
 
 
-#####hygdata_v3.csv:  This is the current version (3) of the HYG stellar database.  It is similar to the version 2 (hygxyz.csv) file, but has a few updates.  The older file is now deprecated.
+##### hygdata_v3.csv:  This is the current version (3) of the HYG stellar database.  It is similar to the version 2 (hygxyz.csv) file, but has a few updates.  The older file is now deprecated.
 
 1. All stars now have both an epoch and equinox of 2000.0.  In v2 of the catalog, all three primary source catalogs either had or were adjusted to equinox 2000, but all 3 had different epochs, leading to small position errors at high magnifications.
 2. The Flamsteed numbers now include many that were not in the _Yale Bright Star Catalog_, the
@@ -27,8 +27,8 @@ Fields in the database:
 4. hr: The star's ID in the Harvard Revised catalog, which is the same as its number in the Yale Bright Star Catalog.
 5. gl: The star's ID in the third edition of the Gliese Catalog of Nearby Stars.
 6. bf: The Bayer / Flamsteed designation, primarily from the Fifth Edition of the Yale Bright Star Catalog. This is a combination of the two designations. The Flamsteed number, if present, is given first; then a three-letter abbreviation for the Bayer Greek letter; the Bayer superscript number, if present; and finally, the three-letter constellation abbreviation. Thus Alpha Andromedae has the field value "21Alp And", and Kappa1 Sculptoris (no Flamsteed number) has "Kap1Scl".
-7. ra, dec: The star's right ascension and declination, for epoch and equinox 2000.0. 
-8. proper: A common name for the star, such as "Barnard's Star" or "Sirius". I have taken these names primarily from the Hipparcos project's web site, which lists representative names for the 150 brightest stars and many of the 150 closest stars. I have added a few names to this list. Most of the additions are designations from catalogs mostly now forgotten (e.g., Lalande, Groombridge, and Gould ["G."]) except for certain nearby stars which are still best known by these designations.
+7. proper: A common name for the star, such as "Barnard's Star" or "Sirius". I have taken these names primarily from the Hipparcos project's web site, which lists representative names for the 150 brightest stars and many of the 150 closest stars. I have added a few names to this list. Most of the additions are designations from catalogs mostly now forgotten (e.g., Lalande, Groombridge, and Gould ["G."]) except for certain nearby stars which are still best known by these designations.
+8. ra, dec: The star's right ascension and declination, for epoch and equinox 2000.0. 
 9. dist: The star's distance in parsecs, the most common unit in astrometry. To convert parsecs to light years, multiply by 3.262. A value >= 100000 indicates missing or dubious (e.g., negative) parallax data in Hipparcos.
 10. pmra, pmdec:  The star's proper motion in right ascension and declination, in milliarcseconds per year.  
 11. rv:  The star's radial velocity in km/sec, where known.
@@ -38,7 +38,7 @@ Fields in the database:
 15. ci: The star's color index (blue magnitude - visual magnitude), where known.
 16. x,y,z: The Cartesian coordinates of the star, in a system based on the equatorial coordinates as seen from Earth. +X is in the direction of the vernal equinox (at epoch 2000), +Z towards the north celestial pole, and +Y in the direction of R.A. 6 hours, declination 0 degrees.
 17. vx,vy,vz: The Cartesian velocity components of the star, in the same coordinate system described immediately above. They are determined from the proper motion and the radial velocity (when known). The velocity unit is parsecs per year; these are small values (around 1 millionth of a parsec per year), but they enormously simplify calculations using parsecs as base units for celestial mapping.
-18. rarad, decrad, pmrarad, prdecrad:  The positions in radians, and proper motions in radians per year.
+18. rarad, decrad, pmrarad, pmdecrad:  The positions in radians, and proper motions in radians per year.
 19. bayer:  The Bayer designation as a distinct value
 20. flam:  The Flamsteed number as a distinct value
 21. con:  The standard constellation abbreviation
@@ -47,7 +47,7 @@ Fields in the database:
 24. var:  Star's standard variable star designation, when known.
 25. var\_min, var\_max:  Star's approximate magnitude range, for variables.  This value is based on the Hp magnitudes for the range in the original Hipparcos catalog, adjusted to the V magnitude scale to match the "mag" field.
 
-#####dso.csv:  This is a collection of deep-sky objects used in http://www.astronexus.com/endeavour/chart.  
+##### dso.csv:  This is a collection of deep-sky objects used in http://www.astronexus.com/endeavour/chart.  
 There are approximately 220K objects, mostly galaxies, but also all known NGC and IC objects.
 
 
@@ -87,7 +87,7 @@ Catalogs represented in the database:
 
 These are still available, but are no longer current or being actively updated, and should be considered deprecated for higher-precision applications.
 
-#####hygfull.csv:
+##### hygfull.csv:
 
 1. StarID: The database primary key from a larger "master database" of stars.
 2. HD: The star's ID in the Henry Draper catalog, if known.
@@ -102,7 +102,7 @@ These are still available, but are no longer current or being actively updated, 
 11. Spectrum: The star's spectral type, if known.
 12. ColorIndex: The star's color index (blue magnitude - visual magnitude), where known.
                                                        
-#####hygxyz.csv: the fields in hygfull, plus some additional fields useful for mapping tools:
+##### hygxyz.csv: the fields in hygfull, plus some additional fields useful for mapping tools:
 
 13. X,Y,Z: The Cartesian coordinates of the star, in a system based on the equatorial coordinates as seen from Earth. +X is in the direction of the vernal equinox (at epoch 2000), +Z towards the north celestial pole, and +Y in the direction of R.A. 6 hours, declination 0 degrees.
 14. VX,VY,VZ: The Cartesian velocity components of the star, in the same coordinate system described immediately above. They are determined from the proper motion and the radial velocity (when known). The velocity unit is parsecs per year; these are small values (around 10-5 to 10-6), but they enormously simplify calculations using parsecs as base units for celestial mapping.


### PR DESCRIPTION
The README file has several problems:
- The order of the columns does not match that of the actual csv file, namely `proper` and `ra, dec` need to be reversed
- The name of the field `pmdecrad` is incorrect and has been spelled `prdecrad`
- The markdown syntax for headings is incorrect